### PR TITLE
Fix dioxus-cli binstall package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repo is broken into 3 components, a CLI, GUI app, and shared-core library t
 * For all three crates: [`rust & cargo`](https://rust-lang.org/tools/install/)
 * For UI: [`dioxus`](https://dioxuslabs.com/learn/0.6/getting_started/)
   * specifically, install `dx` with `cargo install dioxus-cli`
-  * if you have [`binstall`](https://github.com/cargo-bins/cargo-binstall?tab=readme-ov-file#installation), you can skip compiling `dx` from source by running `cargo binstall dx`
+  * if you have [`binstall`](https://github.com/cargo-bins/cargo-binstall?tab=readme-ov-file#installation), you can skip compiling `dx` from source by running `cargo binstall dioxus-cli`
 
 ### Running CLI commands:
 to run without compiling, use `cargo run` in the `cli` directory:


### PR DESCRIPTION
The package name isn't `dx`, though the _binary's_ is...