### PR TITLE
fix: init gtk on linux

### DIFF
--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -42,3 +42,6 @@ desktop = [
 ]
 # The feature that are only required for the mobile = ["dioxus/mobile"] build target should be optional and only enabled in the mobile = ["dioxus/mobile"] feature
 mobile = ["dioxus/mobile"]
+
+[target.'cfg(target_os = "linux")'.dependencies]
+gtk = "0.18.2"

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -46,7 +46,11 @@ enum Route {
 }
 
 fn main() {
+    tracing_subscriber::fmt::init();
     dotenv::dotenv().ok();
+
+    #[cfg(all(feature = "desktop", target_os = "linux"))]
+    gtk::init().unwrap();
 
     #[cfg(feature = "desktop")]
     let _tray_icon = init_menu_bar().unwrap();


### PR DESCRIPTION
I'm not sure why dioxus is not doing this already, but without this one-line change `dx serve` fails with GTK errors for me.