### PR TITLE
refactor: remove n0des tickets, no longer used

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ iroh = { version = "0.95", default-features = false }
 iroh-base = { version = "0.95" }
 iroh-tickets = "0.2"
 iroh-metrics = "0.38"
-iroh-n0des = { version = "0.8", features = ["tickets"] }
+iroh-n0des = { version = "0.8" }
 iroh-relay = { version = "0.95" }
 log = "0.4"
 open = "5"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -133,13 +133,9 @@ pub struct ConnectArgs {
     #[clap(long)]
     pub bind: SocketAddr,
 
-    /// three-word-name for a tunnel to connect to.
-    #[clap(long, conflicts_with = "ticket")]
-    pub codename: Option<String>,
-
     /// provide a ticket to drive connection directly.
     #[clap(long, conflicts_with = "codename")]
-    pub ticket: Option<AdvertismentTicket>,
+    pub ticket: AdvertismentTicket,
 }
 
 #[derive(Parser, Debug)]
@@ -263,19 +259,8 @@ async fn main() -> n0_error::Result<()> {
             println!()
         }
         Commands::Connect(args) => {
-            let ConnectArgs {
-                bind,
-                codename,
-                ticket,
-            } = args;
+            let ConnectArgs { bind, ticket } = args;
             let node = ConnectNode::new(repo).await?;
-            let ticket = if let Some(codename) = codename {
-                node.tickets.get(&codename).await?
-            } else if let Some(ticket) = ticket {
-                ticket
-            } else {
-                n0_error::bail_any!("either --codename or --ticket is required");
-            };
 
             let handle = node
                 .connect_and_bind_local(ticket.endpoint, &ticket.data.data, bind)

--- a/lib/src/tests.rs
+++ b/lib/src/tests.rs
@@ -29,10 +29,6 @@ impl TestDiscovery {
 async fn gateway_end_to_end_to_upstream_http() -> Result<()> {
     let discovery = TestDiscovery::default();
 
-    let n0des_endpoint = Endpoint::bind().await?;
-    discovery.add(&n0des_endpoint);
-    let (api_secret, _n0des_router) = n0des_local::start(n0des_endpoint)?;
-
     let temp_dir = tempfile::tempdir()?;
     let repo = Repo::open_or_create(temp_dir.path()).await?;
 
@@ -46,7 +42,7 @@ async fn gateway_end_to_end_to_upstream_http() -> Result<()> {
 
     let codename = proxy_state.info.codename();
 
-    let upstream = ListenNode::with_n0des_api_secret(repo, api_secret.clone()).await?;
+    let upstream = ListenNode::new(repo).await?;
     discovery.add(upstream.endpoint());
     upstream.set_proxy(proxy_state).await?;
 
@@ -88,10 +84,6 @@ async fn gateway_end_to_end_to_upstream_http() -> Result<()> {
 async fn gateway_forward_connect_tunnel() -> Result<()> {
     let discovery = TestDiscovery::default();
 
-    let n0des_endpoint = Endpoint::bind().await?;
-    discovery.add(&n0des_endpoint);
-    let (api_secret, _n0des_router) = n0des_local::start(n0des_endpoint)?;
-
     let temp_dir = tempfile::tempdir()?;
     let repo = Repo::open_or_create(temp_dir.path()).await?;
 
@@ -103,7 +95,7 @@ async fn gateway_forward_connect_tunnel() -> Result<()> {
         ProxyState::new(advertisment)
     };
 
-    let upstream = ListenNode::with_n0des_api_secret(repo, api_secret.clone()).await?;
+    let upstream = ListenNode::new(repo).await?;
     discovery.add(upstream.endpoint());
     upstream.set_proxy(proxy_state).await?;
 
@@ -160,10 +152,6 @@ async fn gateway_forward_connect_tunnel() -> Result<()> {
 async fn gateway_forward_h2c_requests_are_stable() -> Result<()> {
     let discovery = TestDiscovery::default();
 
-    let n0des_endpoint = Endpoint::bind().await?;
-    discovery.add(&n0des_endpoint);
-    let (api_secret, _n0des_router) = n0des_local::start(n0des_endpoint)?;
-
     let temp_dir = tempfile::tempdir()?;
     let repo = Repo::open_or_create(temp_dir.path()).await?;
 
@@ -175,7 +163,7 @@ async fn gateway_forward_h2c_requests_are_stable() -> Result<()> {
         ProxyState::new(advertisment)
     };
 
-    let upstream = ListenNode::with_n0des_api_secret(repo, api_secret.clone()).await?;
+    let upstream = ListenNode::new(repo).await?;
     discovery.add(upstream.endpoint());
     upstream.set_proxy(proxy_state).await?;
 
@@ -236,10 +224,6 @@ async fn gateway_forward_h2c_requests_are_stable() -> Result<()> {
 async fn gateway_forward_h2c_handles_closed_origin_connections() -> Result<()> {
     let discovery = TestDiscovery::default();
 
-    let n0des_endpoint = Endpoint::bind().await?;
-    discovery.add(&n0des_endpoint);
-    let (api_secret, _n0des_router) = n0des_local::start(n0des_endpoint)?;
-
     let temp_dir = tempfile::tempdir()?;
     let repo = Repo::open_or_create(temp_dir.path()).await?;
 
@@ -251,7 +235,7 @@ async fn gateway_forward_h2c_handles_closed_origin_connections() -> Result<()> {
         ProxyState::new(advertisment)
     };
 
-    let upstream = ListenNode::with_n0des_api_secret(repo, api_secret.clone()).await?;
+    let upstream = ListenNode::new(repo).await?;
     discovery.add(upstream.endpoint());
     upstream.set_proxy(proxy_state).await?;
 


### PR DESCRIPTION
The app is no longer using the n0des tickets feature. Proxies are now stored in the Datum Cloud APIs instead.
This removes the functionality to publish and resolve tickets via n0des.
It *does* keep the n0des endpoint, for metrics collection. However this is now optional, so the app will work without a N0DES_API_SECRET without any issues, only metrics collection onto n0des will be disabled.

Writing this PR shows that, in my opinion, another refactor is due: The logic to update proxies both in the local state (actually accept requests on a new tunnel) and on datum (store the connector and advertisment in the Datum API) currently lives in the ui crate only. See the various `save_create_tunnel` / `save_proxy` signals. This is not very clean IMO and quite error-prone. This should all be handled by the TunnelService, which already contains a ListenNode and a DatumCloudClient. I'll create an issue for this.