### PR TITLE
chore: ensure tls crypto provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,6 +485,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c34dda4df7017c8db52132f0f8a2e0f8161649d15723ed63fc00c82d0f2081a"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1002,6 +1024,15 @@ name = "clap_lex"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+
+[[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "cobs"
@@ -1568,6 +1599,7 @@ dependencies = [
  "objc2-foundation",
  "open",
  "rand 0.9.2",
+ "rustls",
  "snafu",
  "tokio",
  "tokio-util",
@@ -2848,6 +2880,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futf"
@@ -7461,6 +7499,7 @@ version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -7525,6 +7564,7 @@ version = "0.103.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ postcard = "1"
 quinn = { version = "0.14", package = "iroh-quinn" }
 rand = "0.9"
 reqwest = { version = "0.12", features = ["rustls-tls", "json"] }
+rustls = { version = "0.23", features = ["ring"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.145"
 serde_yml = "0.0.12"

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -38,6 +38,7 @@ tracing-appender.workspace = true
 data-encoding.workspace = true
 uuid.workspace = true
 n0-error.workspace = true
+rustls.workspace = true
 dioxus-primitives = { git = "https://github.com/DioxusLabs/components", version = "0.0.1", default-features = false }
 
 [features]

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -60,6 +60,11 @@ enum Route {
 }
 
 fn main() {
+    // Required before any TLS use (e.g. iroh, reqwest). Without this, the app panics when run from Applications.
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("rustls default crypto provider");
+
     init_tracing();
     if let Ok(path) = dotenv::dotenv() {
         info!("Loaded environment variables from {}", path.display());


### PR DESCRIPTION
* rustls 0.23 requires a process‑wide CryptoProvider to be installed before any TLS use