### PR TITLE
fix: make origin click properly

### DIFF
--- a/ui/src/views/proxies_list.rs
+++ b/ui/src/views/proxies_list.rs
@@ -449,7 +449,7 @@ pub fn TunnelCard(
                             } else {
                                 a {
                                     class: "text-xs text-foreground",
-                                    href: format!("http://{}", display_endpoint_href),
+                                    href: display_endpoint_href.clone(),
                                     {display_endpoint}
                                 }
                             }


### PR DESCRIPTION
## Summary

When I clicked on origin URLs from the app, my browser tried to open a link like `http//localhost:3000` (note the missing colon). This fixes the malformed `http://http://localhost:3000` URL in tunnel link hrefs.

## Bug Description
The UI displays clickable links for tunnel endpoints, but clicking them results in `http://http://` instead of `http://`. This happens because the backend already stores endpoints with the `http://` prefix, but the UI incorrectly adds it again when building the href.

## Root Cause
**Location**: `ui/src/views/proxies_list.rs:452`

The `normalize_endpoint` function in `lib/src/tunnels.rs:838-847` adds `http://` when storing endpoints:
```rust
fn normalize_endpoint(endpoint: &str) -> String {
    if endpoint.contains("://") {
        return endpoint.to_string();
    }
    format!("http://{endpoint}")  // Adds http://
}
```

But the UI incorrectly added it again:
```rust
href: format!("http://{}", display_endpoint_href),
```

If `display_endpoint_href` = `http://localhost:5173`, the href becomes `http://http://localhost:5173`.

## Fix Applied
Changed line 452 in `proxies_list.rs` from:
```rust
href: format!("http://{}", display_endpoint_href),
```
to:
```rust
href: display_endpoint_href.clone(),
```

## Verification
- Code compiles successfully with `cargo check`
- Only existing warnings (unrelated to this change)