### PR TITLE
fix(nix): disable check phase to avoid network sandbox failures

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,6 +64,7 @@
           ];
 
           cargoBuildFlags = [ "--workspace" ];
+          doCheck = false; # tests require network (iroh STUN/relay); run with `cargo test` locally
 
           meta = with pkgs.lib; {
             description = "Datum Connect - A tunneling solution built on iroh";
@@ -98,6 +99,7 @@
           ];
 
           cargoBuildFlags = [ "-p" "datum-connect" ];
+          doCheck = false; # tests require network (iroh STUN/relay); run with `cargo test` locally
 
           meta = with pkgs.lib; {
             description = "Datum Connect CLI";


### PR DESCRIPTION
## Summary

I made a mistake before. I _thought_ I had tried `nix run` but it doesn't work. Now I have and it was because the nix-derived test blocks network access. This makes it all work.

- Adds `doCheck = false` to both `packages.default` and `packages.cli` in `flake.nix`
- Prevents `nix run`/`nix build` from running `cargo test` inside Nix's network-sandboxed environment
- Tests use `iroh::Endpoint::bind()` which contacts STUN/relay servers — incompatible with the build sandbox

## Test plan

- [x] `nix run` / `nix build` completes without test failures
- [x] `cargo test` still passes locally as before

