### PR TITLE
feat(nix): add desktop flake target to run app in dev mode

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -150,6 +150,18 @@
         };
 
         formatter = pkgs.nixpkgs-fmt;
+
+        apps.desktop = let
+          script = pkgs.writeShellScriptBin "desktop-app" ''
+            cd "$PWD/ui"
+            export DATUM_CONNECT_PUBLISH_TICKETS=1
+            export RUST_LOG=info,lib::heartbeat=debug,lib::tunnels=debug
+            exec ${pkgs.dioxus-cli}/bin/dx serve --platform desktop
+          '';
+        in {
+          type = "app";
+          program = "${script}/bin/desktop-app";
+        };
       }
     );
 }


### PR DESCRIPTION
The default nix target just runs the main binary. Often I need to actually run:

```
( cd ui && DATUM_CONNECT_PUBLISH_TICKETS=1 RUST_LOG=info,lib::heartbeat=debug,lib::tunnels=debug dx serve --platform desktop )
```

This adds a `desktop` target which does that. 

Run with `nix run .#desktop`