### PR TITLE
Install Sentry cli correctly

### DIFF
--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -150,9 +150,12 @@ jobs:
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
         run: |
           if [ -n "$SENTRY_AUTH_TOKEN" ]; then
-            cargo binstall sentry-cli --force -y
+            export INSTALL_DIR=$HOME/.local/bin
+            mkdir -p "$INSTALL_DIR"
+            export PATH="$INSTALL_DIR:$PATH"
+            curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=3.2.3 sh
             sentry-cli debug-files upload --include-sources \
-              target/dx/Datum/release/macos/Datum.app/Contents/MacOS/
+              ui/target/dx/Datum/release/macos/Datum.app/Contents/MacOS/
           else
             echo "SENTRY_AUTH_TOKEN not set, skipping debug symbol upload"
           fi
@@ -215,9 +218,12 @@ jobs:
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
         run: |
           if [ -n "$SENTRY_AUTH_TOKEN" ]; then
-            cargo binstall sentry-cli --force -y
+            export INSTALL_DIR=$HOME/.local/bin
+            mkdir -p "$INSTALL_DIR"
+            export PATH="$INSTALL_DIR:$PATH"
+            curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=3.2.3 sh
             sentry-cli debug-files upload --include-sources \
-              target/dx/Datum/release/linux/
+              ui/target/dx/Datum/release/linux/
           else
             echo "SENTRY_AUTH_TOKEN not set, skipping debug symbol upload"
           fi
@@ -242,9 +248,10 @@ jobs:
         shell: pwsh
         run: |
           if ($env:SENTRY_AUTH_TOKEN) {
-            cargo binstall sentry-cli --force -y
-            sentry-cli debug-files upload --include-sources `
-              target/dx/Datum/release/windows/
+            $version = "3.2.3"
+            $url = "https://github.com/getsentry/sentry-cli/releases/download/$version/sentry-cli-Windows-x86_64.exe"
+            Invoke-WebRequest -Uri $url -OutFile sentry-cli.exe -UseBasicParsing
+            .\sentry-cli.exe debug-files upload --include-sources ui/target/dx/Datum/release/windows/
           } else {
             Write-Host "SENTRY_AUTH_TOKEN not set, skipping debug symbol upload"
           }


### PR DESCRIPTION
The CI was trying to use cargo to install the Sentry CLI but it's not available there. Changed to direct downloads.