### PR TITLE
Re-enable waf when creating a tunnel

### DIFF
--- a/lib/src/tunnels.rs
+++ b/lib/src/tunnels.rs
@@ -1120,4 +1120,3 @@ fn publish_tickets_enabled() -> bool {
         .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
         .unwrap_or(false)
 }
-


### PR DESCRIPTION
This PR adds the creation of a `trafficProtectionPolicy` back when creating a proxy.


https://github.com/user-attachments/assets/da78988f-07b2-4400-b866-7bc05ae8c022

