### PR TITLE
Fix Homebrew releases

### DIFF
--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -520,7 +520,6 @@ jobs:
           DMG_FILE=$(find macos-dist -name "*.dmg" | head -1)
           DMG_SHA=$(sha256sum "$DMG_FILE" | cut -d' ' -f1)
           REPO="datum-cloud/app"
-          BRANCH="release/desktop-${TAG}"
 
           git clone https://x-access-token:${GH_TOKEN}@github.com/datum-cloud/homebrew-tap.git tap
           mkdir -p tap/Casks
@@ -545,14 +544,7 @@ jobs:
           cd tap
           git config user.name "Datum Release Bot"
           git config user.email "releases@datum.net"
-          git checkout -b "${BRANCH}"
           git add Casks/
           git diff --cached --quiet && exit 0
           git commit -m "Brew cask update for Datum Desktop version ${TAG}"
-          git push origin "${BRANCH}"
-          gh pr create \
-            --title "Brew cask update for Datum Desktop version ${TAG}" \
-            --body "Automated cask update from release workflow." \
-            --base main \
-            --head "${BRANCH}" \
-            --repo datum-cloud/homebrew-tap
+          git push

--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -497,6 +497,14 @@ jobs:
     # Stable tags only — beta/pre-release builds must not replace the Homebrew cask
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && needs.release.outputs.is_prerelease == 'false'
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
+          repositories: homebrew-tap
+
       - name: Download macOS artifacts
         uses: actions/download-artifact@v7
         with:
@@ -505,15 +513,16 @@ jobs:
 
       - name: Update Homebrew Tap
         env:
-          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG: ${{ github.ref_name }}
         run: |
           VERSION="${TAG#v}"
           DMG_FILE=$(find macos-dist -name "*.dmg" | head -1)
           DMG_SHA=$(sha256sum "$DMG_FILE" | cut -d' ' -f1)
           REPO="datum-cloud/app"
+          BRANCH="release/desktop-${TAG}"
 
-          git clone https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/datum-cloud/homebrew-tap.git tap
+          git clone https://x-access-token:${GH_TOKEN}@github.com/datum-cloud/homebrew-tap.git tap
           mkdir -p tap/Casks
           rm -f tap/Casks/datum.rb
 
@@ -536,6 +545,14 @@ jobs:
           cd tap
           git config user.name "Datum Release Bot"
           git config user.email "releases@datum.net"
+          git checkout -b "${BRANCH}"
           git add Casks/
-          git diff --cached --quiet || git commit -m "Brew cask update for Datum Desktop version ${TAG}"
-          git push
+          git diff --cached --quiet && exit 0
+          git commit -m "Brew cask update for Datum Desktop version ${TAG}"
+          git push origin "${BRANCH}"
+          gh pr create \
+            --title "Brew cask update for Datum Desktop version ${TAG}" \
+            --body "Automated cask update from release workflow." \
+            --base main \
+            --head "${BRANCH}" \
+            --repo datum-cloud/homebrew-tap


### PR DESCRIPTION
## What happened
Releases were failing because our automation was trying to push directly to the Homebrew tap, which requires changes to go through a pull request.

## What changed
- Switched from a personal access token to the **Datum Release Bot** GitHub App, which can bypass branch protection and push directly to the tap

## Before merging
Make sure the Datum Release Bot GitHub App is:
- [x] Created in the datum-cloud org
- [x] Installed on `datum-cloud/homebrew-tap`
- [x] Added as a bypass actor in the tap's branch ruleset