### PR TITLE
feat: default Connector connectorClassName to iroh-quic-tunnel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1952,7 +1952,7 @@ dependencies = [
 [[package]]
 name = "dioxus-attributes"
 version = "0.1.0"
-source = "git+https://github.com/DioxusLabs/components#ffbc750181ea2195e20736ae3ad0c24ad9684c41"
+source = "git+https://github.com/DioxusLabs/components?rev=ffbc750181ea2195e20736ae3ad0c24ad9684c41#ffbc750181ea2195e20736ae3ad0c24ad9684c41"
 dependencies = [
  "dioxus-rsx",
  "proc-macro2",
@@ -2328,7 +2328,7 @@ dependencies = [
 [[package]]
 name = "dioxus-primitives"
 version = "0.0.1"
-source = "git+https://github.com/DioxusLabs/components#ffbc750181ea2195e20736ae3ad0c24ad9684c41"
+source = "git+https://github.com/DioxusLabs/components?rev=ffbc750181ea2195e20736ae3ad0c24ad9684c41#ffbc750181ea2195e20736ae3ad0c24ad9684c41"
 dependencies = [
  "dioxus",
  "dioxus-attributes",
@@ -4937,9 +4937,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -7957,9 +7957,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -9996,9 +9996,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -10009,9 +10009,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -10019,9 +10019,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -10029,9 +10029,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -10042,9 +10042,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -10098,9 +10098,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/lib/src/tunnels.rs
+++ b/lib/src/tunnels.rs
@@ -34,7 +34,7 @@ use gateway_api::apis::standard::httproutes::{
 };
 
 const DEFAULT_PCP_NAMESPACE: &str = "default";
-const DEFAULT_CONNECTOR_CLASS_NAME: &str = "datum-connect";
+const DEFAULT_CONNECTOR_CLASS_NAME: &str = "iroh-quic-tunnel";
 const CONNECTOR_SELECTOR_FIELD: &str = "status.connectionDetails.publicKey.id";
 const ADVERTISEMENT_CONNECTOR_FIELD: &str = "spec.connectorRef.name";
 const DISPLAY_NAME_ANNOTATION: &str = "app.kubernetes.io/name";

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -39,7 +39,11 @@ data-encoding.workspace = true
 uuid.workspace = true
 n0-error.workspace = true
 rustls.workspace = true
-dioxus-primitives = { git = "https://github.com/DioxusLabs/components", version = "0.0.1", default-features = false }
+# Pinned to a known-good rev: the upstream repo is a moving 0.0.1 git dep
+# with no published versioning, and bundle CI runs `cargo generate-lockfile`,
+# so without a rev pin every CI run picks up upstream HEAD and breaks
+# whenever the Select/Props API drifts. Bump deliberately, never via auto-resolve.
+dioxus-primitives = { git = "https://github.com/DioxusLabs/components", rev = "ffbc750181ea2195e20736ae3ad0c24ad9684c41", version = "0.0.1", default-features = false }
 sentry.workspace = true
 
 [features]


### PR DESCRIPTION
## Summary
- Switch `DEFAULT_CONNECTOR_CLASS_NAME` from `datum-connect` to `iroh-quic-tunnel`.
- Companion change in `datum-cloud/milo` provisions the new `iroh-quic-tunnel` ConnectorClass on every project (existing projects keep their legacy `datum-connect` class as well, so older builds still resolve).
- The Connector resource's `metadata.generateName` prefix is intentionally left as `datum-connect-` for now; that is cosmetic resource naming, not the class ref.

## Test plan
- [ ] Build a desktop binary from this branch, connect to a project, confirm the Connector resolves under `iroh-quic-tunnel`.
- [ ] Verify older builds (still defaulting to `datum-connect`) continue to work against existing projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)