### PR TITLE
fix(dns_dev): emit one addr= TXT entry per address

### DIFF
--- a/cli/src/dns_dev.rs
+++ b/cli/src/dns_dev.rs
@@ -161,12 +161,18 @@ fn build_catalog(config_path: &PathBuf, fallback_origin: &str) -> n0_error::Resu
         let z32_id = z32::encode(endpoint_id.as_bytes());
         let name = Name::from_str(&format!("_iroh.{z32_id}.{origin}.")).anyerr()?;
 
+        // iroh's parser (iroh-relay/src/endpoint_info.rs) runs
+        // SocketAddr::from_str on each IrohAttr::Addr value as-is and
+        // silently drops failures, and its serializer emits one
+        // (Addr, addr.to_string()) attribute per IP. So the canonical
+        // wire form is one "addr=<single-sockaddr>" TXT entry per
+        // address, not one "addr=A B C" line.
         let mut txt_entries = Vec::new();
         if let Some(relay) = record.relay {
             txt_entries.push(format!("relay={relay}"));
         }
-        if !record.addrs.is_empty() {
-            txt_entries.push(format!("addr={}", record.addrs.join(" ")));
+        for addr in &record.addrs {
+            txt_entries.push(format!("addr={addr}"));
         }
         if txt_entries.is_empty() {
             continue;


### PR DESCRIPTION
## Summary
The dev DNS responder in \`cli/src/dns_dev.rs\` was joining all direct addresses into a single \`addr=A B C\` TXT line. iroh's parser does not split on whitespace — it runs \`SocketAddr::from_str\` on each \`IrohAttr::Addr\` value as-is and silently drops failures. So endpoints served via this dev DNS would parse to zero direct addresses on the dialer side; only the \`relay=\` entry survived.

iroh's serializer at \`iroh-relay/src/endpoint_info.rs:511-520\`:

```rust
TransportAddr::Ip(addr) => attrs.push((IrohAttr::Addr, addr.to_string())),
```

…pushes **one** \`(Addr, ...)\` attribute per IP. The canonical wire form is multiple \`addr=<single-sockaddr>\` TXT entries.

## Change
Replace the join with a loop emitting one \`addr=\${addr}\` TXT entry per address. Same approach as the corresponding fix in \`network-services-operator\` (datum-cloud/network-services-operator#147), discovered when staging iroh-gateway logs showed an \`EndpointInfo\` with only \`Relay(...)\` despite the DNS containing \`addr=\` records.