### PR TITLE
chore: enable Sentry release reporting and bump Dioxus to 0.7.9

### DIFF
--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -46,9 +46,11 @@ jobs:
             libxdo-dev
 
       - name: Install Dioxus CLI
-        # Should be pinned to same version as dioxus in Cargo.toml
-        # note: dx bundle on Windows fails with 0.7.3, see
+        # Library deps in ui/Cargo.toml are pinned to dioxus =0.7.9, but the CLI is
+        # held back at 0.7.2 because dx bundle path resolution regressed in 0.7.3+
+        # and the upstream fix is still open:
         # https://github.com/DioxusLabs/dioxus/issues/5233
+        # Bump in lockstep with the lib once that issue is resolved.
         run: cargo binstall dioxus-cli@0.7.2 --disable-telemetry --locked --force -y
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -153,6 +155,10 @@ jobs:
       - name: Bundle (macOS)
         if: runner.os == 'macOS'
         working-directory: ./ui
+        env:
+          # Baked into the binary via `option_env!("SENTRY_DSN")` in ui/src/main.rs.
+          # If the secret isn't set the binary just runs without Sentry reporting.
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: dx bundle --locked --desktop --release --package-types macos
 
       - name: Build DMG (appdmg)
@@ -182,6 +188,26 @@ jobs:
           fi
           codesign --force --sign "$APPLE_SIGNING_IDENTITY" --timestamp ui/dist/Datum.dmg
 
+      - name: Generate dSYM (macOS)
+        if: runner.os == 'macOS' && startsWith(github.ref, 'refs/tags/v')
+        run: |
+          # `debug = "line-tables-only"` in workspace Cargo.toml leaves DWARF
+          # distributed across the `.o` files in target/<triple>/<profile>/deps/
+          # with only N_OSO references in the binary. Without a .dSYM bundle
+          # sentry-cli has nothing to symbolicate against on macOS, so we run
+          # dsymutil manually and stage the result outside the .app bundle so
+          # it doesn't get packaged into the DMG.
+          BIN="ui/target/dx/Datum/release/macos/Datum.app/Contents/MacOS/Datum"
+          DSYM_DIR="$RUNNER_TEMP/dsyms"
+          mkdir -p "$DSYM_DIR"
+          if [ ! -f "$BIN" ]; then
+            echo "Bundled binary not found at $BIN" >&2
+            exit 1
+          fi
+          dsymutil "$BIN" -o "$DSYM_DIR/Datum.dSYM"
+          ls -la "$DSYM_DIR/Datum.dSYM"
+          dwarfdump --uuid "$DSYM_DIR/Datum.dSYM"
+
       - name: Upload Debug Symbols to Sentry (macOS)
         if: runner.os == 'macOS' && startsWith(github.ref, 'refs/tags/v')
         env:
@@ -196,6 +222,7 @@ jobs:
             export PATH="$INSTALL_DIR:$PATH"
             curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=3.2.3 sh
             sentry-cli debug-files upload --include-sources \
+              "$RUNNER_TEMP/dsyms" \
               ui/target/dx/Datum/release/macos/Datum.app/Contents/MacOS/
           else
             echo "SENTRY_AUTH_TOKEN not set, skipping debug symbol upload"
@@ -255,6 +282,8 @@ jobs:
         # For now we set NO_STRIP, which makes the bundles *huge*...
         env:
           NO_STRIP: true
+          # Baked into the binary via `option_env!("SENTRY_DSN")` in ui/src/main.rs.
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: dx bundle --locked --desktop --release --package-types appimage
 
       - name: Repack AppImage using system libs (Linux)
@@ -390,6 +419,9 @@ jobs:
       - name: Bundle (Windows)
         working-directory: ./ui
         if: runner.os == 'Windows'
+        env:
+          # Baked into the binary via `option_env!("SENTRY_DSN")` in ui/src/main.rs.
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: dx bundle --locked --desktop --release --package-types nsis
 
       - name: Upload Debug Symbols to Sentry (Windows)

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -50,9 +50,11 @@ jobs:
             libxdo-dev
 
       - name: Install Dioxus CLI
-        # Should be pinned to same version as dioxus in Cargo.toml
-        # note: dx bundle on Windows fails with 0.7.3, see
+        # Library deps in ui/Cargo.toml are pinned to dioxus =0.7.9, but the CLI is
+        # held back at 0.7.2 because dx bundle path resolution regressed in 0.7.3+
+        # and the upstream fix is still open:
         # https://github.com/DioxusLabs/dioxus/issues/5233
+        # Bump in lockstep with the lib once that issue is resolved.
         run: cargo binstall dioxus-cli@0.7.2 --disable-telemetry --locked --force -y
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -139,6 +141,10 @@ jobs:
       - name: Bundle (macOS)
         if: runner.os == 'macOS'
         working-directory: ./ui
+        env:
+          # Baked into the binary via `option_env!("SENTRY_DSN")` in ui/src/main.rs.
+          # If the secret isn't set the binary just runs without Sentry reporting.
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: dx bundle --locked --desktop --release --package-types macos
 
       - name: Build DMG (appdmg)
@@ -215,6 +221,8 @@ jobs:
         # For now we set NO_STRIP, which makes the bundles *huge*...
         env:
           NO_STRIP: true
+          # Baked into the binary via `option_env!("SENTRY_DSN")` in ui/src/main.rs.
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: dx bundle --locked --desktop --release --package-types appimage
 
       - name: Repack AppImage using system libs (Linux)
@@ -314,6 +322,9 @@ jobs:
       - name: Bundle (Windows)
         working-directory: ./ui
         if: runner.os == 'Windows'
+        env:
+          # Baked into the binary via `option_env!("SENTRY_DSN")` in ui/src/main.rs.
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: dx bundle --locked --desktop --release --package-types nsis
 
       - name: Upload artifacts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1901,9 +1901,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus"
-version = "0.7.3"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b583b48ac77158495e6678fe3a2b5954fc8866fc04cb9695dd146e88bc329d"
+checksum = "7c01ecf7ddbae18a419ad3d83c486101a85ffc5740ea09cdd0f09a30dc12170d"
 dependencies = [
  "dioxus-asset-resolver",
  "dioxus-cli-config",
@@ -1930,9 +1930,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-asset-resolver"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8b546050ecfc7fcd310be344b2f3a2a79f21554c5a9e8df28e7a07e9b36009b"
+checksum = "69387edbbc60c7cb93ad96d8cc7a22b49a76e21643380b89b1c49a78d347ff60"
 dependencies = [
  "dioxus-cli-config",
  "http 1.4.0",
@@ -1962,18 +1962,18 @@ dependencies = [
 
 [[package]]
 name = "dioxus-cli-config"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ad73f0ff638cd27466d389cd57f0975f909b66130dc1c25d5212d4041e5352"
+checksum = "c000f584ddf608e2b272b3074bf11512a474eeeb2eb85a1915f276ce5c4a8615"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "dioxus-config-macro"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e004bc8b958031117d373db2b5e0ab9d7e763751de129dd36f00ef7e318333cd"
+checksum = "7637091592978fbfdb45a16b26bd99fd97fb1bd7e31c6a963530e00c022af321"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1981,15 +1981,15 @@ dependencies = [
 
 [[package]]
 name = "dioxus-config-macros"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808a9994a9a2623e6b6890b6cc68def24bd669177ec4713684447fb46418c256"
+checksum = "54f9ed8fc1a215ad34bb8dbae42a4ea54efbcd26ca9006bbe5cca78e511bf25f"
 
 [[package]]
 name = "dioxus-core"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "247ed8d679a13232641f1c84ba22246623fae01320b4c22db225c0b4f2fa7398"
+checksum = "45887100ff0cf89abeb8b659808294fda48cd53f3b424e36407dedffcfea830b"
 dependencies = [
  "anyhow",
  "const_format",
@@ -2009,9 +2009,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-core-macro"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75fbe64029b90144041f8521300c7b3508e6c48caea3244de2ff5d1ade15390c"
+checksum = "370c63663dff0f24df5dfea643ca239283542c6b228a302f69b32e1d36762b7f"
 dependencies = [
  "convert_case 0.8.0",
  "dioxus-rsx",
@@ -2022,16 +2022,17 @@ dependencies = [
 
 [[package]]
 name = "dioxus-core-types"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbfea5c8946e0745b254b5c33c515d81b3ba638f33c2a532ed06730392394d4d"
+checksum = "36963eab106b169737762f9cd5ee5fd97f585989dcb2d8e30a596e97a6999009"
 
 [[package]]
 name = "dioxus-desktop"
-version = "0.7.3"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6ec66749d1556636c5b4f661495565c155a7f78a46d4d007d7478c6bdc288c"
+checksum = "662cd78c73ca3f17346adbf2d64757df40dd0ce20536c05123097fd31828d2bd"
 dependencies = [
+ "anyhow",
  "async-trait",
  "base64 0.22.1",
  "bytes",
@@ -2052,9 +2053,10 @@ dependencies = [
  "futures-util",
  "generational-box",
  "global-hotkey",
+ "image",
  "infer",
  "jni 0.21.1",
- "lazy-js-bundle 0.7.6",
+ "lazy-js-bundle 0.7.9",
  "libc",
  "muda",
  "ndk",
@@ -2076,16 +2078,16 @@ dependencies = [
  "tokio",
  "tracing",
  "tray-icon",
- "tungstenite 0.27.0",
+ "tungstenite 0.28.0",
  "webbrowser",
  "wry",
 ]
 
 [[package]]
 name = "dioxus-devtools"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d30370fa78266aed3f3d9119dea2de9e92a0348941dbfa777f7a669f2ea375"
+checksum = "2349cedbdf1b429df1f1bea61fdee0ad3dae7b2548eedfbeca82710122a57da0"
 dependencies = [
  "dioxus-cli-config",
  "dioxus-core",
@@ -2101,9 +2103,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-devtools-types"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3907a2b61cf56039f047da6a37317a03d9e15411753bc40e5e34a27e405ac320"
+checksum = "0ab9b0f7565d1916b70915f59b89ea8054ef0a9d67a364a32bbee68ef5f3818d"
 dependencies = [
  "dioxus-core",
  "serde",
@@ -2112,9 +2114,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-document"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b75a1809af7c13546ae4487c8b02ab80cc4d059e7db5a5d090374ceaa71d5b"
+checksum = "37e3a5bec7ffc999ff23446a487eb5cd86111d1574a23533dd3f8b3c69a53a22"
 dependencies = [
  "dioxus-core",
  "dioxus-core-macro",
@@ -2123,7 +2125,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "generational-box",
- "lazy-js-bundle 0.7.6",
+ "lazy-js-bundle 0.7.9",
  "serde",
  "serde_json",
  "tracing",
@@ -2131,9 +2133,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-fullstack"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ee56dd65fbf1222fa6a2749c3f821df28facf1832854b43d480b547a096f6d"
+checksum = "37f0558edb88af5ad47275ae36a7f06317163ba482db377c26d7d8590b5cd0f6"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2167,7 +2169,7 @@ dependencies = [
  "js-sys",
  "mime",
  "pin-project",
- "reqwest",
+ "reqwest 0.12.28",
  "rustversion",
  "send_wrapper",
  "serde",
@@ -2188,9 +2190,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-fullstack-core"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40d33a447cb158acdb61787b2ff52dd8a0f9a9f20e95e5c5fe9873f01c2b55b"
+checksum = "cc634b28b4b1e3eab1e8df4f98510e2d2fa39d686321467f977213155e86ed2b"
 dependencies = [
  "anyhow",
  "axum-core 0.5.6",
@@ -2216,9 +2218,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-fullstack-macro"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c06eb66bce50d5f47b793e6af5fc2e0a511bf2b4fa2423cf86e35023d8f17e6"
+checksum = "85a8fe7da549859fae00c7f4bf11a2aab734ae7ef6f98f280dce9bea1f3326ec"
 dependencies = [
  "const_format",
  "convert_case 0.8.0",
@@ -2230,9 +2232,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-history"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1d8024afd482956eadae2c43d0b1e73e584adb724ac09be87f268d52002387b"
+checksum = "1a15232302d1933015fcf2d6fe9e286ad36f6e9c205a546089a0f326023bb0d2"
 dependencies = [
  "dioxus-core",
  "tracing",
@@ -2240,9 +2242,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-hooks"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233b5e168a7c38c4bf96d0f390221a72a5a28bb31ce2dcf6d2af879dc561ef42"
+checksum = "4534f91cf6305204b948bdec130076ac9ecc7c22faab29475b76870558bf73ea"
 dependencies = [
  "dioxus-core",
  "dioxus-signals",
@@ -2256,9 +2258,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-html"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4abf4ad27eee650d1ab8ebe13591e8b0ee595fa5a5dd236be13a5b7b3fab678d"
+checksum = "e03d6ad4040b667f2b2eefcb678840e630938c09bf9ec39b04ea4d1d96d90d44"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2273,7 +2275,7 @@ dependencies = [
  "futures-util",
  "generational-box",
  "keyboard-types",
- "lazy-js-bundle 0.7.6",
+ "lazy-js-bundle 0.7.9",
  "rustversion",
  "serde",
  "serde_json",
@@ -2283,9 +2285,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-html-internal-macro"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025e107e677f790f4ed648a189e36f51ae014e5341902b97313e4eae626cffa2"
+checksum = "584e2772127ab00f0d5e1d4d9795f39fecebc828ece0b7a02349d438bc1b1ce7"
 dependencies = [
  "convert_case 0.8.0",
  "proc-macro2",
@@ -2295,15 +2297,15 @@ dependencies = [
 
 [[package]]
 name = "dioxus-interpreter-js"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57caa76427d8ec4105ccca44ff8c511055688af732a094b9fe9ef3547d2a11b2"
+checksum = "11999d6eb5bb179a9512dad30e5de408aab66f2cb65de9098c9fbe02927e2978"
 dependencies = [
  "dioxus-core",
  "dioxus-core-types",
  "dioxus-html",
  "js-sys",
- "lazy-js-bundle 0.7.6",
+ "lazy-js-bundle 0.7.9",
  "rustc-hash 2.1.2",
  "serde",
  "sledgehammer_bindgen",
@@ -2315,9 +2317,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-logger"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cbbee192b1b12fccb444a5b04d809710cfce4d27b792129fea6c845fae7f329"
+checksum = "a28ccdfe36d2cb830a2784e40f7e6f7199805a2c6da99bd65b1ca308f11aed28"
 dependencies = [
  "dioxus-cli-config",
  "tracing",
@@ -2342,9 +2344,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-router"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecdb19d7a1489ba252be9b3a07f9db92814020eb4ba8c1306f04242a44d17e66"
+checksum = "38e47f62d680429badfcb99bf5dec17ee92b0cb9623f264e36bc003a1359bfdc"
 dependencies = [
  "dioxus-cli-config",
  "dioxus-core",
@@ -2362,9 +2364,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-router-macro"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b525ab775585f1dc4850178de9d0cb6bb37f7b9c1a1a0c121eab7449d7021480"
+checksum = "6f83fb667d27e256f8c9eca49963fbace66a8722cb64ee15a10ffc97d092357e"
 dependencies = [
  "base16",
  "digest 0.10.7",
@@ -2377,9 +2379,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-rsx"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37fb07e40e9734946511659668ea3675ed214b60889e7aa7f0a5a85271518475"
+checksum = "2106afda239a4c7c22ffa1ca19117011225fc1c735c139c0a5b765996aa8bb1d"
 dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
@@ -2402,9 +2404,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-signals"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5393fd579f42c6547bf47ec0a2dedf2a366cd541d31deedc1059a096e6c35798"
+checksum = "3705754f5e043deec9fc7af0d159f18e5b21c02c47d255c7e477f31368f0b6d2"
 dependencies = [
  "dioxus-core",
  "futures-channel",
@@ -2418,9 +2420,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-stores"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c59f52e8194439604dd35f8c540456c22b4a4b076930e424d0289f98ea3cb4"
+checksum = "64bec7b21c86b1360ec965a07a53a2c96b7caee3465049e1c299a45024e87614"
 dependencies = [
  "dioxus-core",
  "dioxus-signals",
@@ -2430,9 +2432,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-stores-macro"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "737600865572cecf60ff934f88252bd4144f4ca189e0e570b7a780e8f0e01a1f"
+checksum = "40a5875e9f890f27b1cc3e5b56c1e23601211470315a1fb8627c4ca4f3b2be9a"
 dependencies = [
  "convert_case 0.8.0",
  "proc-macro2",
@@ -2442,9 +2444,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-web"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176eb0a5ee8251203a816b413a64fdc014b43e53d4245f769b1b0c2035b88ac3"
+checksum = "bc0a0be76b404e8242a597db0fb239d05f8dee4e7856bc1fc7144f7e244822fd"
 dependencies = [
  "dioxus-cli-config",
  "dioxus-core",
@@ -2460,7 +2462,7 @@ dependencies = [
  "generational-box",
  "gloo-timers",
  "js-sys",
- "lazy-js-bundle 0.7.6",
+ "lazy-js-bundle 0.7.9",
  "rustc-hash 2.1.2",
  "send_wrapper",
  "serde",
@@ -3294,9 +3296,9 @@ dependencies = [
 
 [[package]]
 name = "generational-box"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68d74be1fbe3bba37604bdfd61403f26af9f6324cf325053abd89d60c22e799"
+checksum = "8cd0d825b8d339701ad330dbcd6399519ced4d143484954daf6e3185dace4f77"
 dependencies = [
  "parking_lot",
  "tracing",
@@ -4401,7 +4403,7 @@ dependencies = [
  "portable-atomic",
  "portmapper",
  "rand 0.9.4",
- "reqwest",
+ "reqwest 0.12.28",
  "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
@@ -4558,7 +4560,7 @@ dependencies = [
  "n0-error",
  "n0-future",
  "pin-project",
- "reqwest",
+ "reqwest 0.12.28",
  "tokio",
  "tokio-util",
  "tracing",
@@ -4648,7 +4650,7 @@ dependencies = [
  "pkarr",
  "postcard",
  "rand 0.9.4",
- "reqwest",
+ "reqwest 0.12.28",
  "rustls",
  "rustls-pki-types",
  "serde",
@@ -5105,9 +5107,9 @@ checksum = "e49596223b9d9d4947a14a25c142a6e7d8ab3f27eb3ade269d238bb8b5c267e2"
 
 [[package]]
 name = "lazy-js-bundle"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebbde2c5796719fbd82d6b8ec0be3dacf1f70c2876dee0f2c001632794d6641f"
+checksum = "ccafada6c9541db44db758619236f2748f6e1bdaa84d04ded858567cd1e89321"
 
 [[package]]
 name = "lazy_static"
@@ -5169,7 +5171,7 @@ dependencies = [
  "pkcs8 0.11.0-rc.11",
  "postcard",
  "rand 0.9.4",
- "reqwest",
+ "reqwest 0.12.28",
  "secrecy",
  "semver",
  "sentry",
@@ -5414,9 +5416,9 @@ dependencies = [
 
 [[package]]
 name = "manganis"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e06225f29a781d86afdfafa562de09621f2ace377136ae2ae9ca9e72a29b920"
+checksum = "8bfcf56309de35b48b8780ea097ace5c3b773a617b52edc49dfc9a63a7d9dc43"
 dependencies = [
  "const-serialize 0.7.2",
  "const-serialize 0.8.0-alpha.0",
@@ -5430,9 +5432,9 @@ dependencies = [
 
 [[package]]
 name = "manganis-core"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "774ddc382b4fb30f3fdcf2418131cbac5e6111f00e6c7ddf9e598ef3b2b4cd91"
+checksum = "a24d6be68f594495aea60850a284029d585d7b7839b26096c1b6d758f8518648"
 dependencies = [
  "const-serialize 0.7.2",
  "const-serialize 0.8.0-alpha.0",
@@ -5444,9 +5446,9 @@ dependencies = [
 
 [[package]]
 name = "manganis-macro"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731c83c89d831f341fb46eba0aefdfb3433f77a3f78a8b08d9d88746613a8f8b"
+checksum = "5e782a10318d707c0833e31876ded8acf91287eee0010af8392559af614c7226"
 dependencies = [
  "dunce",
  "macro-string",
@@ -6170,7 +6172,7 @@ dependencies = [
  "getrandom 0.2.17",
  "http 1.4.0",
  "rand 0.8.6",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -7786,7 +7788,6 @@ dependencies = [
  "cookie",
  "cookie_store",
  "encoding_rs",
- "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -7824,6 +7825,45 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -8233,13 +8273,14 @@ dependencies = [
 
 [[package]]
 name = "sentry"
-version = "0.42.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989425268ab5c011e06400187eed6c298272f8ef913e49fcadc3fda788b45030"
+checksum = "931a20b0da02350676e3d6d3c9028d58eaa448cf42a866712eec5845a505421e"
 dependencies = [
+ "cfg_aliases",
  "httpdate",
  "native-tls",
- "reqwest",
+ "reqwest 0.13.3",
  "sentry-actix",
  "sentry-backtrace",
  "sentry-contexts",
@@ -8253,9 +8294,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-actix"
-version = "0.42.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5c675bdf6118764a8e265c3395c311b4d905d12866c92df52870c0223d2ffc1"
+checksum = "5ffb8fd78b8f4527146013ab52293e03242770a31dcd97eee4b82b7f770ffab3"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -8266,9 +8307,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.42.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68e299dd3f7bcf676875eee852c9941e1d08278a743c32ca528e2debf846a653"
+checksum = "911ee36abf5b7fa335fccd5f54361ba9c16baea5f0c3bb361a687b6c195c21cf"
 dependencies = [
  "backtrace",
  "regex",
@@ -8277,9 +8318,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.42.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac0c5d6892cd4c414492fc957477b620026fb3411fca9fa12774831da561c88"
+checksum = "9b9d7d469e9e22741c17ca23fb8b42d79861590eb7cf330f3da34fc1e4bc1bc6"
 dependencies = [
  "hostname",
  "libc",
@@ -8291,9 +8332,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.42.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deaa38b94e70820ff3f1f9db3c8b0aef053b667be130f618e615e0ff2492cbcc"
+checksum = "545dc562b6758d646ac19e1407f4ebc26d452111386743e03323464bc48bb2e0"
 dependencies = [
  "rand 0.9.4",
  "sentry-types",
@@ -8304,9 +8345,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-debug-images"
-version = "0.42.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00950648aa0d371c7f57057434ad5671bd4c106390df7e7284739330786a01b6"
+checksum = "660e9def38a573a869a182f7e90f58aaaa460f38b92b31fd1755ec537193bb48"
 dependencies = [
  "findshlibs",
  "sentry-core",
@@ -8314,9 +8355,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.42.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b7a23b13c004873de3ce7db86eb0f59fe4adfc655a31f7bbc17fd10bacc9bfe"
+checksum = "772d9de150c8ca910c835353c85f434457348fdd21208f9b3da3574202b1dc5d"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -8324,9 +8365,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-tracing"
-version = "0.42.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac841c7050aa73fc2bec8f7d8e9cb1159af0b3095757b99820823f3e54e5080"
+checksum = "c51ec9620a4d398dcdf7ee90effbf8d8691cfa24e91978bfa8565cac039d4980"
 dependencies = [
  "bitflags 2.11.1",
  "sentry-backtrace",
@@ -8337,9 +8378,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.42.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e477f4d4db08ddb4ab553717a8d3a511bc9e81dde0c808c680feacbb8105c412"
+checksum = "041359745a44dd2e14fe21b7510fe7ca8b5beffce6636a0b52e5bc7d5f736887"
 dependencies = [
  "debugid",
  "hex",
@@ -8959,9 +9000,9 @@ dependencies = [
 
 [[package]]
 name = "subsecond"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feae81a4a7ca6d0bcf70c385a43b7dbacbff527f0805cb0a4043ce2c2c559a2c"
+checksum = "9cc79674bd55726e6b123204403389400229a95fe4a3b2c5453dada70b06ca95"
 dependencies = [
  "js-sys",
  "libc",
@@ -8978,9 +9019,9 @@ dependencies = [
 
 [[package]]
 name = "subsecond-types"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85256ee192cbdf00473e48e6133863b125dd4f772fddfbc97287ec7a61458c25"
+checksum = "e9798bfed58797aed51c672aa99810aac30a50d3120ecfdcf28c13784e9a8f1c"
 dependencies = [
  "serde",
 ]
@@ -9670,9 +9711,7 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
- "native-tls",
  "rand 0.9.4",
- "rustls",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
@@ -9689,7 +9728,9 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
+ "native-tls",
  "rand 0.9.4",
+ "rustls",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ n0-error = { version = "0.1", features = ["anyhow"] }
 n0-future = "0.3"
 uuid = { version = "1.18.1", features = ["v4"] }
 url = "2"
-sentry = { version = "0.42.0", features = ["tracing"] }
+sentry = { version = "0.48.2", features = ["tracing"] }
 
 [profile]
 

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,0 +1,5 @@
+// Re-run the build when `SENTRY_DSN` changes so the value baked into the
+// binary via `option_env!("SENTRY_DSN")` in `src/main.rs` stays in sync.
+fn main() {
+    println!("cargo:rerun-if-env-changed=SENTRY_DSN");
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -134,28 +134,44 @@ pub struct ConnectArgs {
 
 #[tokio::main]
 async fn main() -> n0_error::Result<()> {
-    tracing_subscriber::registry()
-        .with(tracing_subscriber::fmt::layer())
-        .with(sentry::integrations::tracing::layer())
-        .init();
-    if let Ok(path) = dotenv::dotenv() {
-        info!("Loaded environment variables from {}", path.display());
-    }
+    // Load .env first so any process-env-driven config is visible to the rest
+    // of init. We keep the load result so we can log it *after* tracing is up.
+    let dotenv_path = dotenv::dotenv().ok();
 
+    // Initialize Sentry before tracing so the tracing layer registered below
+    // dispatches to a real Hub from the first event onwards. SENTRY_DSN is
+    // baked at compile time via `option_env!`; dev builds typically have no
+    // DSN, so Sentry naturally runs as a no-op outside release builds.
     let _sentry_guard = sentry::init(sentry::ClientOptions {
-        dsn: std::env::var("SENTRY_DSN")
-            .ok()
+        dsn: option_env!("SENTRY_DSN")
+            .filter(|s| !s.is_empty())
             .and_then(|s| s.parse().ok()),
         release: sentry::release_name!(),
         send_default_pii: true,
-        before_send: Some(std::sync::Arc::new(|event| match event.level {
-            sentry::Level::Error | sentry::Level::Fatal => Some(event),
-            _ if rand::random::<f64>() < 0.1 => Some(event),
-            _ => None,
-        })),
         traces_sample_rate: 0.1,
         ..Default::default()
     });
+
+    // Promote WARN to a Sentry event in addition to the default ERROR -> Event
+    // and INFO -> Breadcrumb. See ui/src/main.rs for rationale.
+    let sentry_layer = sentry::integrations::tracing::layer().event_filter(|md| {
+        use sentry::integrations::tracing::EventFilter;
+        match *md.level() {
+            tracing::Level::ERROR => EventFilter::Event | EventFilter::Breadcrumb,
+            tracing::Level::WARN => EventFilter::Event | EventFilter::Breadcrumb,
+            tracing::Level::INFO => EventFilter::Breadcrumb,
+            _ => EventFilter::Ignore,
+        }
+    });
+
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
+        .with(sentry_layer)
+        .init();
+
+    if let Some(path) = dotenv_path {
+        info!("Loaded environment variables from {}", path.display());
+    }
 
     let args = Args::parse();
 

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -13,8 +13,8 @@ name = "Datum"
 path = "src/main.rs"
 
 [dependencies]
-dioxus = { version = "=0.7.3", features = ["router"] }
-dioxus-desktop = { version = "=0.7.3", optional = true }
+dioxus = { version = "=0.7.9", features = ["router"] }
+dioxus-desktop = { version = "=0.7.9", optional = true }
 image = "0.25"
 
 chrono.workspace = true

--- a/ui/build.rs
+++ b/ui/build.rs
@@ -1,0 +1,7 @@
+// Re-run the build when `SENTRY_DSN` changes so the value baked into the
+// binary via `option_env!("SENTRY_DSN")` in `src/main.rs` stays in sync.
+// Without this, cargo will happily reuse a cached artifact even after the
+// env var changes.
+fn main() {
+    println!("cargo:rerun-if-env-changed=SENTRY_DSN");
+}

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -126,25 +126,33 @@ fn main() {
         .install_default()
         .expect("rustls default crypto provider");
 
-    init_tracing();
-    if let Ok(path) = dotenv::dotenv() {
-        info!("Loaded environment variables from {}", path.display());
-    }
+    // Load .env first so any process-env-driven config (DATUM_API_ENV, etc.) is
+    // visible to the rest of init. We keep the load result so we can log it
+    // *after* tracing is set up.
+    let dotenv_path = dotenv::dotenv().ok();
 
+    // Initialize Sentry before tracing so the tracing layer registered below
+    // dispatches to a real Hub from the first event onwards.
+    //
+    // SENTRY_DSN is read at compile time via `option_env!`. CI release builds
+    // bake it in (see .github/workflows/bundle.yml). Dev builds typically
+    // have no SENTRY_DSN at compile time, so Sentry naturally runs as a
+    // no-op in development.
     let _sentry_guard = sentry::init(sentry::ClientOptions {
-        dsn: std::env::var("SENTRY_DSN")
-            .ok()
+        dsn: option_env!("SENTRY_DSN")
+            .filter(|s| !s.is_empty())
             .and_then(|s| s.parse().ok()),
         release: sentry::release_name!(),
         send_default_pii: true,
-        before_send: Some(std::sync::Arc::new(|event| match event.level {
-            sentry::Level::Error | sentry::Level::Fatal => Some(event),
-            _ if rand::random::<f64>() < 0.1 => Some(event),
-            _ => None,
-        })),
         traces_sample_rate: 0.1,
         ..Default::default()
     });
+
+    init_tracing();
+
+    if let Some(path) = dotenv_path {
+        info!("Loaded environment variables from {}", path.display());
+    }
 
     #[cfg(all(feature = "desktop", target_os = "linux"))]
     gtk::init().unwrap();
@@ -172,8 +180,14 @@ fn main() {
             .with_fullsize_content_view(true);
 
         let mut config = Config::new()
-            // Make "close" behave like hide, so the tray icon can restore it.
+            // Close-as-hide: the user re-opens the window via the tray menu's
+            // "Show Window" item (see init_tray and the muda event handler).
             .with_close_behaviour(WindowCloseBehaviour::WindowHides)
+            // Left-clicking the tray icon should only surface the context menu,
+            // not unhide the main window. Restoring is an explicit action
+            // through the tray menu rather than an accidental side-effect of
+            // clicking the icon.
+            .with_tray_icon_show_window_on_click(false)
             .with_window(window_builder);
 
         dioxus::LaunchBuilder::desktop()
@@ -197,12 +211,26 @@ fn init_tracing() {
     let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
     let _ = LOG_GUARD.set(guard);
 
+    // Promote WARN to a Sentry event (in addition to the default ERROR -> Event
+    // and INFO -> Breadcrumb). The codebase uses `warn!` for most meaningful
+    // failure paths (auth, kube, refresh) and very few `error!` sites, so the
+    // default filter sends almost nothing to Sentry.
+    let sentry_layer = sentry::integrations::tracing::layer().event_filter(|md| {
+        use sentry::integrations::tracing::EventFilter;
+        match *md.level() {
+            tracing::Level::ERROR => EventFilter::Event | EventFilter::Breadcrumb,
+            tracing::Level::WARN => EventFilter::Event | EventFilter::Breadcrumb,
+            tracing::Level::INFO => EventFilter::Breadcrumb,
+            _ => EventFilter::Ignore,
+        }
+    });
+
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
     tracing_subscriber::registry()
         .with(filter)
         .with(fmt::layer().with_writer(std::io::stderr))
         .with(fmt::layer().with_writer(non_blocking))
-        .with(sentry::integrations::tracing::layer())
+        .with(sentry_layer)
         .init();
 }
 


### PR DESCRIPTION
## Summary

- Bake `SENTRY_DSN` at compile time via `option_env!` so release builds actually report events; add `build.rs` files so cargo rebuilds when `SENTRY_DSN` changes.
- Initialize Sentry **before** `tracing_subscriber` so events from the first log onwards land on a real Hub.
- Promote `WARN` to a Sentry event (the codebase prefers `warn!` for failure paths; the default filter sent almost nothing).
- CI: pass `SENTRY_DSN` to `dx bundle` in `bundle.yml` / `manual-release.yml`, and run `dsymutil` on macOS so `.dSYM` bundles upload alongside the artifact.
- Bump `dioxus` / `dioxus-desktop` 0.7.3 → 0.7.9 and use the new `with_tray_icon_show_window_on_click(false)` so left-clicking the tray icon only surfaces the menu instead of unhiding the main window.
