### PR TITLE
fix(ci): stop release bot from regressing Homebrew cask fixes

### DIFF
--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -635,12 +635,13 @@ jobs:
             version "${VERSION}"
             sha256 "${DMG_SHA}"
 
-            url "https://github.com/${REPO}/releases/download/${TAG}/Datum.dmg"
+            url "https://github.com/${REPO}/releases/download/v#{version}/Datum.dmg",
+              verified: "github.com/${REPO}/"
             name "Datum"
             desc "Quickly and safely expose local environments to the internet, for free."
             homepage "https://www.datum.net/"
 
-            depends_on macos: ">= :big_sur"
+            depends_on macos: :big_sur
 
             app "Datum.app"
           end


### PR DESCRIPTION
## Summary
- The `update-homebrew` job in `bundle.yml` regenerates `Casks/desktop.rb` from a hardcoded heredoc on every stable release.
- That template predated datum-cloud/homebrew-tap#3 and was reverting its fixes (`verified:` url, `#{version}` interpolation, `depends_on macos: :big_sur` symbol) on every subsequent release — most recently v0.1.0.
- This updates the template so future releases stop clobbering those fixes.

## Test plan
- [x] Rendered the updated heredoc locally with sample values and confirmed output matches the intended cask format byte-for-byte.
- [ ] Next stable tag release will exercise the real workflow end-to-end.