### PR TITLE
fix: restore project overlay so the dialog renders properly

### DIFF
--- a/ui/src/views/select_project.rs
+++ b/ui/src/views/select_project.rs
@@ -350,7 +350,7 @@ pub fn SelectProject() -> Element {
                 }
             }
             // Overlay (full screen backdrop)
-            div { class: "bg-foreground/30 mt-[32px] fixed inset-0 z-50 flex items-center justify-center animate-in fade-in duration-100 backdrop-blur-[2px]",
+            div { class: "bg-foreground/30 fixed inset-0 z-50 flex items-center justify-center animate-in fade-in duration-100 backdrop-blur-[2px]",
                 // Form dialog centered on top
                 div { class: "w-full max-w-lg mx-auto p-8 bg-card-background rounded-lg border border-card-border shadow-card relative z-50",
                     div { class: "mb-6",


### PR DESCRIPTION
## Problem

The "Where to manage your tunnels" dialog overlay had a 32px gap at the top of the viewport where the background wasnt dimmed.

Qwen 3.6 did a surprisingly good job finding this. I tested locally and it restores the dialog. 

## Cause

Commit 8baf811 added `mt-[32px]` to the overlay div, which has `fixed inset-0`. The margin pushed the overlay down 32px, leaving a gap at the top. Since the Chrome layouts AppHeader is rendered **outside** the SelectProject outlet, the overlay should cover the full viewport.

@mattdjenkinson not sure the intention of your original change, so this could be off?

## Fix

Remove `mt-[32px]` from the overlay class list.

Fixes #167